### PR TITLE
Build process fix due to gftools no longer generating `build.ninja`

### DIFF
--- a/Lib/notobuilder/__main__.py
+++ b/Lib/notobuilder/__main__.py
@@ -46,7 +46,7 @@ def main(args=None):
     if args.graph:
         pd.draw_graph()
     if not args.no_ninja:
-        result = subprocess.run(["ninja"])
+        result = subprocess.run(["ninja", "-f", pd.ninja_file_name])
         sys.exit(result.returncode)
 
 


### PR DESCRIPTION
Due to https://github.com/googlefonts/gftools/commit/ebad92951e6bfd8c72a547da1cee95c9708ba1df, `gftools` no longer produces a `build.ninja` file, meaning running `ninja` results in an error.

This PR fixes this by grabbing the unique `.ninja` filename from `GFBuilder()`